### PR TITLE
Bug/2554 fix avatar initials and timestamps

### DIFF
--- a/UI/libs/core-admin/src/lib/components/permits/permit-detail/tabs/BackgroundCheckTab.vue
+++ b/UI/libs/core-admin/src/lib/components/permits/permit-detail/tabs/BackgroundCheckTab.vue
@@ -101,7 +101,6 @@
                           item.value
                         ].value !== null
                       "
-                      v-model="dialog"
                       width="800"
                       :retain-focus="false"
                     >
@@ -127,7 +126,6 @@
                           </span>
                         </v-list-item-avatar>
                       </template>
-
                       <v-card>
                         <v-card-title> Change made by: </v-card-title>
                         <v-card-text>
@@ -163,16 +161,6 @@
                           </v-row>
                         </v-card-text>
                         <v-divider></v-divider>
-                        <v-card-actions>
-                          <v-spacer></v-spacer>
-                          <v-btn
-                            color="error"
-                            text
-                            @click="dialog = false"
-                          >
-                            Close
-                          </v-btn>
-                        </v-card-actions>
                       </v-card>
                     </v-dialog>
                   </v-col>
@@ -299,7 +287,10 @@ function handlePass(itemValue: string, itemLabel: string) {
   changed.value = itemLabel;
   permitStore.getPermitDetail.application.backgroundCheck[
     itemValue
-  ].changeMadeBy = authStore.getAuthState.userEmail;
+  ].changeMadeBy = authStore.getAuthState.userName;
+  permitStore.getPermitDetail.application.backgroundCheck[
+    itemValue
+  ].changeDateTimeUtc = new Date();
   updatePermitDetails();
 }
 

--- a/UI/libs/core-admin/src/lib/components/permits/permit-detail/tabs/BackgroundCheckTab.vue
+++ b/UI/libs/core-admin/src/lib/components/permits/permit-detail/tabs/BackgroundCheckTab.vue
@@ -116,23 +116,28 @@
                               permitStore.getPermitDetail.application
                                 .backgroundCheck[item.value]
                                 ? formatInitials(
-                                    authStore.getAuthState.userName.split(
-                                      ', '
-                                    )[1],
-                                    authStore.getAuthState.userName
+                                    permitStore.getPermitDetail.application.backgroundCheck[
+                                      item.value
+                                    ].changeMadeBy.split(', ')[1],
+                                    permitStore.getPermitDetail.application
+                                      .backgroundCheck[item.value].changeMadeBy
                                   )
                                 : ''
                             }}
                           </span>
                         </v-list-item-avatar>
                       </template>
-                      <v-card>
+                      <v-card min-height="135">
                         <v-card-title> Change made by: </v-card-title>
                         <v-card-text>
+                          <v-divider></v-divider>
+                          <v-row>
+                            <v-col></v-col>
+                          </v-row>
                           <v-row
                             align="center"
                             justify="center"
-                            class="mt-2"
+                            class="text-center"
                           >
                             <v-col>
                               {{
@@ -160,7 +165,6 @@
                             </v-col>
                           </v-row>
                         </v-card-text>
-                        <v-divider></v-divider>
                       </v-card>
                     </v-dialog>
                   </v-col>
@@ -299,10 +303,12 @@ function handleFail(itemValue: string) {
     false;
   permitStore.getPermitDetail.application.backgroundCheck[
     itemValue
-  ].changeMadeBy = authStore.getAuthState.userEmail;
+  ].changeMadeBy = authStore.getAuthState.userName;
+  permitStore.getPermitDetail.application.backgroundCheck[
+    itemValue
+  ].changeDateTimeUtc = new Date();
   updatePermitDetails();
 }
 
 const settings = ref([]);
-const dialog = ref(false);
 </script>


### PR DESCRIPTION
# Description
- Update handlePass and handleFail functions to display proper time and date.

- Additionally, clicking on an avatar will now properly display the correct user and changes made by. 

- Updated logic that grabs avatar initials to grab from permitStore instead of authStore.

Fixes # issue ticket number and link
AB#2554

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)




