### PR TITLE
Update defaultFormatters.ts

### DIFF
--- a/UI/libs/shared/utils/src/lib/formatters/defaultFormatters.ts
+++ b/UI/libs/shared/utils/src/lib/formatters/defaultFormatters.ts
@@ -54,6 +54,7 @@ export function formatDate(dateStr: string): string {
       year: '2-digit',
       month: '2-digit',
       day: '2-digit',
+      timeZone: 'UTC',
     }) || dateStr
   )
 }


### PR DESCRIPTION
Fix date of birth on admin side displaying birthday incorrectly by 1 day. Added timeZone: UTC to formatDate

[AB#2614](https://dev.azure.com/dsd-sdsd/c59f7cfe-fbe6-43ba-85f4-23bca3c651c6/_workitems/edit/2614)
