### PR TITLE
bug: fix middle initial null

### DIFF
--- a/API/CCW.Application/Controllers/PermitApplicationController.cs
+++ b/API/CCW.Application/Controllers/PermitApplicationController.cs
@@ -1662,7 +1662,11 @@ public class PermitApplicationController : ControllerBase
             string fullname = BuildApplicantFullName(userApplication);
             form.GetField("LAST_NAME").SetValue(userApplication.Application.PersonalInfo?.LastName ?? "", true);
             form.GetField("FIRST_NAME").SetValue(userApplication.Application.PersonalInfo?.FirstName ?? "", true);
-            form.GetField("MIDDLE_INITIAL").SetValue(userApplication.Application.PersonalInfo?.MiddleName.Substring(0,1) ?? "", true);
+            if(userApplication.Application.PersonalInfo?.MiddleName != null)
+            {
+                form.GetField("MIDDLE_INITIAL").SetValue(userApplication.Application.PersonalInfo?.MiddleName.Substring(0,1) ?? "", true);
+            }
+            
             form.GetField("SUFFIX").SetValue(userApplication.Application.PersonalInfo?.Suffix ?? "", true);
             if(userApplication.Application.Aliases.Length > 0)
             {


### PR DESCRIPTION
# Description

Middle Initial check for null when printing livescan

Fixes # issue ticket number and link
[AB#2613](https://dev.azure.com/dsd-sdsd/c59f7cfe-fbe6-43ba-85f4-23bca3c651c6/_workitems/edit/2613)
