### PR TITLE
Add validation to signature step continue button

### DIFF
--- a/UI/libs/core-public/src/lib/components/form-stepper/form-steps/SignatureStep.vue
+++ b/UI/libs/core-public/src/lib/components/form-stepper/form-steps/SignatureStep.vue
@@ -46,6 +46,7 @@
       <v-divider class="mb-5" />
       <FormButtonContainer
         :valid="valid"
+        :loading="state.uploading"
         @submit="handleSubmit"
         @save="handleSave"
       />
@@ -126,6 +127,7 @@ const state = reactive({
   signature: '',
   previousSignature: false,
   submited: false,
+  uploading: false,
 })
 
 const model = computed({
@@ -167,6 +169,7 @@ const fileMutation = useMutation({
 
 async function handleSubmit() {
   state.submited = true
+  state.uploading = true
   const image = document.getElementById('signatureCanvas')
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -212,6 +215,9 @@ async function handleFileUpload() {
     .catch(e => {
       window.console.warn(e)
       Promise.reject()
+    })
+    .finally(() => {
+      state.uploading = false
     })
 }
 

--- a/UI/libs/shared/ui/src/lib/components/containers/FormButtonContainer.vue
+++ b/UI/libs/shared/ui/src/lib/components/containers/FormButtonContainer.vue
@@ -4,14 +4,22 @@
       class="mr-2"
       color="primary"
       @click="handleSubmit"
-      :disabled="!props.valid"
+      :disabled="!props.valid || props.loading"
+      style="width: 200px"
     >
-      {{ $t('Continue') }}
+      <v-progress-circular
+        v-if="props.loading"
+        indeterminate
+        size="24"
+        color="white"
+      />
+      <span v-else>{{ $t('Continue') }}</span>
     </v-btn>
     <v-btn
       color="primary"
       @click="handleSave"
-      :disabled="!props.valid"
+      :disabled="!props.valid || props.loading"
+      style="width: 200px"
     >
       {{ $t('Save and Exit') }}
     </v-btn>
@@ -21,10 +29,12 @@
 <script setup lang="ts">
 interface FormButtonContainerProps {
   valid?: boolean
+  loading?: boolean
 }
 
 const props = withDefaults(defineProps<FormButtonContainerProps>(), {
   valid: false,
+  loading: false,
 })
 
 const emit = defineEmits(['submit', 'save'])


### PR DESCRIPTION
- Disable continue button once clicked to prevent multiple signature uploads

- Add loading indicator to continue button

[AB#2639](https://dev.azure.com/dsd-sdsd/c59f7cfe-fbe6-43ba-85f4-23bca3c651c6/_workitems/edit/2639)
