### PR TITLE
fix: Appointment time conflicts with UTC conversion

### DIFF
--- a/API/CCW.Schedule/Services/CosmosDbService.cs
+++ b/API/CCW.Schedule/Services/CosmosDbService.cs
@@ -485,6 +485,11 @@ public class CosmosDbService : ICosmosDbService
                 var endTime = appointmentManagement.FirstAppointmentStartTime.Add(TimeSpan.FromMinutes(appointmentManagement.AppointmentLength));
                 var lastAppointmentStartTime = appointmentManagement.LastAppointmentStartTime;
 
+                if (lastAppointmentStartTime < startTime)
+                {
+                    lastAppointmentStartTime = lastAppointmentStartTime.Add(TimeSpan.FromDays(1));
+                }
+
                 while (startTime <= lastAppointmentStartTime)
                 {
                     if (appointmentManagement.BreakStartTime != null && WillAppointmentFallInBreakTime(appointmentManagement, startTime))

--- a/UI/libs/core-admin/src/lib/components/templates/AppointmentTemplate.vue
+++ b/UI/libs/core-admin/src/lib/components/templates/AppointmentTemplate.vue
@@ -19,6 +19,7 @@
 
         <v-btn
           @click="handleSaveAppointments"
+          :disabled="invalidTime"
           color="primary"
           class="mr-4"
         >
@@ -51,6 +52,7 @@
               <v-text-field
                 v-model="selectedStartTime"
                 @change="handleChangeAppointmentParameters"
+                :error-messages="startTimeError"
                 append-icon="mdi-clock-time-four-outline"
                 label="First appointment start time"
                 type="time"
@@ -61,6 +63,7 @@
               <v-text-field
                 v-model="selectedEndTime"
                 @change="handleChangeAppointmentParameters"
+                :error-messages="startTimeError"
                 append-icon="mdi-clock-time-four-outline"
                 label="Last appointment start time"
                 type="time"
@@ -176,6 +179,7 @@ const selectedAppointmentLength = ref(30)
 const selectedNumberOfWeeks = ref(1)
 const selectedBreakLength = ref<number>()
 const selectedBreakStartTime = ref(null)
+const startTimeError = ref('')
 
 const { isLoading, mutate: uploadAppointments } = useMutation({
   mutationKey: ['uploadAppointments'],
@@ -213,6 +217,10 @@ onMounted(() => {
   handleChangeAppointmentParameters()
 })
 
+const invalidTime = computed(() => {
+  return startTimeError.value.length > 0
+})
+
 const getFirstInterval = computed(() => {
   const startTime = parseInt(selectedStartTime.value.split(':')[0])
 
@@ -240,6 +248,17 @@ const getIntervalCount = computed(() => {
 })
 
 function handleChangeAppointmentParameters() {
+  startTimeError.value = ''
+
+  const selectedStart = new Date(`1970-01-01T${selectedStartTime.value}`)
+  const selectedEnd = new Date(`1970-01-01T${selectedEndTime.value}`)
+
+  if (selectedStart >= selectedEnd) {
+    startTimeError.value = 'First appointment must be before last appointment'
+
+    return
+  }
+
   events.value = []
   const today = new Date()
   const firstDayOfWeek = new Date(


### PR DESCRIPTION
When an appointment end time is less than the start time, add a new day.

Add validation to front end to prevent appointment start time being later than final appointment

[AB#3210](https://dev.azure.com/dsd-sdsd/c59f7cfe-fbe6-43ba-85f4-23bca3c651c6/_workitems/edit/3210)