### PR TITLE
fix: agreements pointing to public documents instead of agency

### DIFF
--- a/API/CCW.Document/Controllers/DocumentController.cs
+++ b/API/CCW.Document/Controllers/DocumentController.cs
@@ -405,7 +405,7 @@ public class DocumentController : ControllerBase
 
             MemoryStream ms = new MemoryStream();
 
-            var file = await _azureStorage.DownloadApplicantFileAsync(agreementFileName, cancellationToken: cancellationToken);
+            var file = await _azureStorage.DownloadAgencyFileAsync(agreementFileName, cancellationToken: cancellationToken);
 
             if (await file.ExistsAsync())
             {


### PR DESCRIPTION
# Description

[AB#3189](https://dev.azure.com/dsd-sdsd/c59f7cfe-fbe6-43ba-85f4-23bca3c651c6/_workitems/edit/3189)