### PR TITLE
fix: adding weapons after editing

### DIFF
--- a/UI/libs/shared/ui/src/lib/components/tables/WeaponsTable.vue
+++ b/UI/libs/shared/ui/src/lib/components/tables/WeaponsTable.vue
@@ -121,6 +121,8 @@ function openAddWeaponDialog() {
     caliber: '',
     serialNumber: '',
   }
+  isEditing.value = false
+  editedWeaponIndex.value = -1
   weaponDialog.value = true
 }
 


### PR DESCRIPTION
- Fix bug where adding a weapon after previously clicking edit on a different weapon causes the weapon to be overwritten

[AB#3383](https://dev.azure.com/dsd-sdsd/c59f7cfe-fbe6-43ba-85f4-23bca3c651c6/_workitems/edit/3383)

