### PR TITLE
fix: updating application

### DIFF
--- a/UI/libs/core-public/src/lib/components/form-stepper/form-steps/SignatureStep.vue
+++ b/UI/libs/core-public/src/lib/components/form-stepper/form-steps/SignatureStep.vue
@@ -157,6 +157,10 @@
     <v-container v-else>
       <v-row justify="center">
         <v-alert
+          v-if="
+            !applicationStore.completeApplication.application
+              .isUpdatingApplication
+          "
           outlined
           type="success"
         >

--- a/UI/libs/shared/ui/src/lib/components/containers/FormButtonContainer.vue
+++ b/UI/libs/shared/ui/src/lib/components/containers/FormButtonContainer.vue
@@ -3,7 +3,9 @@
     <v-btn
       v-if="
         !props.isFinalStep ||
-        !applicationStore.completeApplication.application.isUpdatingApplication
+        (!applicationStore.completeApplication.application
+          .isUpdatingApplication &&
+          !props.loading)
       "
       :disabled="!props.valid || props.loading || !props.allStepsComplete"
       :loading="props.loading"
@@ -50,5 +52,10 @@ function handleContinue() {
 
 function handleSave() {
   emit('save')
+
+  if (applicationStore.completeApplication.application.isUpdatingApplication) {
+    applicationStore.completeApplication.application.isUpdatingApplication =
+      false
+  }
 }
 </script>


### PR DESCRIPTION
If updating application, set updating back to false when saving and exiting.

- Fixes inability to continue and reschedule after cancelling appointment



