### PR TITLE
feat: Add 'No documents found' text to docs tabs

### DIFF
--- a/UI/libs/core-admin/src/lib/components/permits/permit-detail/tabs/AdminDocumentsTab.vue
+++ b/UI/libs/core-admin/src/lib/components/permits/permit-detail/tabs/AdminDocumentsTab.vue
@@ -12,6 +12,7 @@
     <v-card-text>
       <template>
         <v-data-table
+          v-if="state.documents.length"
           :headers="state.headers"
           :items="state.documents"
           class="elevation-0"
@@ -41,6 +42,14 @@
               mdi-delete
             </v-icon>
           </template>
+        </v-data-table>
+        <v-data-table
+          v-else
+          :headers="state.headers"
+          :items="state.noDocs"
+          class="elevation-0"
+          :editable="true"
+        >
         </v-data-table>
       </template>
       <v-dialog
@@ -110,6 +119,14 @@ const state = reactive({
     { text: 'UPLOADED BY', value: 'uploadedBy' },
     { text: 'UPLOADED DATE', value: 'uploadedDateTimeUtc' },
     { text: 'ACTIONS', value: 'actions' },
+  ],
+  noDocs: [
+    {
+      name: '',
+      uploadedDateTimeUtc: '',
+      uploadedBy: 'No documents found.',
+      documentType: '',
+    },
   ],
   showDeleteDialog: false,
   itemToDelete: null as UploadedDocType | null,

--- a/UI/libs/core-admin/src/lib/components/permits/permit-detail/tabs/AttachedDocumentsTab.vue
+++ b/UI/libs/core-admin/src/lib/components/permits/permit-detail/tabs/AttachedDocumentsTab.vue
@@ -12,6 +12,7 @@
     <v-card-text>
       <template>
         <v-data-table
+          v-if="state.documents.length"
           :headers="state.headers"
           :items="state.documents"
           class="elevation-0"
@@ -50,6 +51,14 @@
               mdi-delete
             </v-icon>
           </template>
+        </v-data-table>
+        <v-data-table
+          v-else
+          :headers="state.headers"
+          :items="state.noDocs"
+          class="elevation-0"
+          :editable="true"
+        >
         </v-data-table>
       </template>
       <v-dialog
@@ -132,6 +141,14 @@ const state = reactive({
     { text: 'UPLOADED BY', value: 'uploadedBy' },
     { text: 'UPLOADED DATE', value: 'uploadedDateTimeUtc' },
     { text: 'ACTIONS', value: 'actions' },
+  ],
+  noDocs: [
+    {
+      name: '',
+      uploadedDateTimeUtc: '',
+      uploadedBy: 'No documents found.',
+      documentType: '',
+    },
   ],
   showDeleteDialog: false,
   itemToDelete: null as UploadedDocType | null,

--- a/UI/libs/core-public/src/lib/views/RecieptView.vue
+++ b/UI/libs/core-public/src/lib/views/RecieptView.vue
@@ -25,7 +25,7 @@
               successful! {{ brandStore.getBrand.agencyName }} Licensing Staff
               will contact you once the application has been reviewed. Due to
               the volume of applications submitted, it may be several months
-              before staff contacts you.
+              before staff contact you.
             </p>
             <span
               style="color: red"
@@ -44,7 +44,7 @@
               class="mt-5"
               @click="goToDashBoard"
             >
-              Back To Home
+              Back to Home
             </v-btn>
           </v-card-text>
         </v-card>


### PR DESCRIPTION
# Description

Admin site: Add text to documents tabs to detail when there are no documents found.

Fixes # issue ticket number and link
[AB#2745](https://dev.azure.com/dsd-sdsd/c59f7cfe-fbe6-43ba-85f4-23bca3c651c6/_workitems/edit/2745)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] UI unit tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules