### PR TITLE
fix: disable finish renewal and modification buttons if no payment

### DIFF
--- a/UI/libs/core-admin/src/lib/components/dialogs/FinishModificationDialog.vue
+++ b/UI/libs/core-admin/src/lib/components/dialogs/FinishModificationDialog.vue
@@ -5,6 +5,7 @@
   >
     <template #activator="{ on, attrs }">
       <v-btn
+        :disabled="disabled"
         v-on="on"
         v-bind="attrs"
         color="primary"
@@ -70,6 +71,12 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+
+interface Props {
+  disabled: boolean
+}
+
+const props = defineProps<Props>()
 
 const emit = defineEmits(['handle-finish-modification'])
 

--- a/UI/libs/core-admin/src/lib/components/dialogs/FinishRenewalDialog.vue
+++ b/UI/libs/core-admin/src/lib/components/dialogs/FinishRenewalDialog.vue
@@ -5,6 +5,7 @@
   >
     <template #activator="{ on, attrs }">
       <v-btn
+        :disabled="disabled"
         v-on="on"
         v-bind="attrs"
         color="primary"
@@ -69,6 +70,12 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+
+interface Props {
+  disabled: boolean
+}
+
+const props = defineProps<Props>()
 
 const emit = defineEmits(['handle-finish-renewal'])
 

--- a/UI/libs/core-admin/src/lib/components/permits/permit-cards/PermitCard2.vue
+++ b/UI/libs/core-admin/src/lib/components/permits/permit-cards/PermitCard2.vue
@@ -528,6 +528,7 @@
                 </v-alert>
 
                 <FinishModificationDialog
+                  :disabled="!isModificationPaymentComplete"
                   v-if="
                     permitStore.getPermitDetail.application.status ===
                     ApplicationStatus['Modification Approved']
@@ -732,6 +733,7 @@
                 </v-alert>
 
                 <FinishRenewalDialog
+                  :disabled="!isRenewalPaymentComplete"
                   v-if="
                     permitStore.getPermitDetail.application.status ===
                     ApplicationStatus['Renewal Approved']


### PR DESCRIPTION
If the customer hasn't paid yet, disable the finish modification and renewal buttons

[AB#3594](https://dev.azure.com/dsd-sdsd/c59f7cfe-fbe6-43ba-85f4-23bca3c651c6/_workitems/edit/3594)

