### PR TITLE
fix: hide days before renewal if already modifying or renewing

### DIFF
--- a/UI/libs/core-public/src/lib/views/ApplicationDetailView.vue
+++ b/UI/libs/core-public/src/lib/views/ApplicationDetailView.vue
@@ -591,7 +591,7 @@
           </v-card-title>
 
           <v-card-title
-            v-if="!isRenewalActive"
+            v-if="!isRenewalActive && !isModification && !isRenew"
             class="justify-center"
           >
             You can begin your renewal in


### PR DESCRIPTION
# Description

hide days before renewal if already modifying or renewing

